### PR TITLE
Added: Score sandbox project maintainers

### DIFF
--- a/project-maintainers.csv
+++ b/project-maintainers.csv
@@ -1570,3 +1570,7 @@ Sandbox,Connect RPC,Akshay Shah,Buf,akshayjshah,https://github.com/connectrpc/co
 ,,Sri Krishna Paritala,Buf,srikrsna-buf,
 ,,Steve Ayers,Buf,smaye81,
 ,,Timo Stamm,Buf,timostamm,
+Sandbox,Score,Ben Meier,Humanitec,astromechza,https://github.com/score-spec/spec/blob/main/MAINTAINERS.md
+,,Chris Stephenson,Humanitec,chrishumanitec,
+,,Mathieu Benoit,Humanitec,mathieu-benoit,
+,,Susa Tünker,Checkly,sujaya-sys,


### PR DESCRIPTION
This is related to the task list attached to https://github.com/cncf/sandbox/issues/186.

The 4 of us are the core regular maintainers at this time for anything under https://github.com/score-spec.

Please let me know if there are any questions.
